### PR TITLE
fix toolchain version to intel/2016.01, use upstream tarball names, add HPL easyconfig

### DIFF
--- a/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2016.01.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.1-intel-2016.01.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.1'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'intel', 'version': '2016.01'}
+toolchainopts = {'optarch': True, 'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2016.1.150-GCC-4.9.3.eb
@@ -8,7 +8,7 @@ description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_%(version)s.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update%(version_minor)s.tgz']
 
 checksums = ['4b93b0ff549e6bd8d1a8b9a441b235a8']
 

--- a/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2016.1.150-GCC-4.9.3.eb
@@ -8,7 +8,7 @@ description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_%(version)s.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_update%(version_minor)s.tgz']
 
 checksums = ['1e848c8283cf6a0210bce1d35ecd748b']
 

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2016.01-GCC-4.9.3.eb
@@ -2,7 +2,7 @@
 easyblock = "Toolchain"
 
 name = 'iimpi'
-version = '2016.00'
+version = '2016.01'
 versionsuffix = '-GCC-4.9.3'
 
 homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'

--- a/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-11.3.1.150-iimpi-2016.01-GCC-4.9.3.eb
@@ -9,7 +9,7 @@ description = """Intel Math Kernel Library is a library of highly optimized,
  applications that require maximum performance. Core math functions include
  BLAS, LAPACK, ScaLAPACK, Sparse Solvers, Fast Fourier Transforms, Vector Math, and more."""
 
-toolchain = {'name': 'iimpi', 'version': '2016.00-GCC-4.9.3'}
+toolchain = {'name': 'iimpi', 'version': '2016.01-GCC-4.9.3'}
 
 sources = ['l_mkl_%(version)s.tgz']
 checksums = ['b57ff502b5f97f2f783e4bbda7ce42b3']

--- a/easybuild/easyconfigs/i/intel/intel-2016.01.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2016.01.eb
@@ -2,7 +2,7 @@
 easyblock = "Toolchain"
 
 name = 'intel'
-version = '2016.00'
+version = '2016.01'
 
 homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
 description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI & Intel MKL."""


### PR DESCRIPTION
@jas02: as discussed, update for https://github.com/hpcugent/easybuild-easyconfigs/pull/2148
